### PR TITLE
Disable a cosmetic feature --no-print-directory to add BSD make support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,6 @@
 EXTRA_DIST = autogen.sh Makefile.unx make.inc Makefile.nmake About_bsd.txt
 CLEANFILES =
 LDADD =
-AM_MAKEFLAGS = --no-print-directory
 noinst_HEADERS =
 pkginclude_HEADERS = include/test.h
 noinst_LTLIBRARIES =


### PR DESCRIPTION
Disabling --no-print-directory which prints entering/leaving dir messages will fix the compilation problem under freeBSD. Didn't test the library yet 